### PR TITLE
Fix app dependencies

### DIFF
--- a/src/ejwt.app.src
+++ b/src/ejwt.app.src
@@ -6,7 +6,10 @@
   {applications, [
                   kernel,
                   stdlib,
-                  crypto
+                  crypto,
+		  jiffy,
+		  base64url,
+		  ej
                  ]},
   {env, []}
  ]}.


### PR DESCRIPTION
ejwt does not depend on jiffy, base64url and ej in it's app file.

This causes relx to not include those deps in releases using ejwt.
