### PR TITLE
Updating dependencies and switching to tags instead of ref.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,9 @@
 {erl_opts, [warnings_as_errors]}.
 {deps, [
   {jiffy, ".*",     {git, "git://github.com/davisp/jiffy",
-    {tag, "d16a4fd968e000b65e4678cccfad68d7a0a8bd1c"}}},
+    {tag, "0.14.3"}}},
   {base64url, ".*", {git, "git://github.com/dvv/base64url.git",
-    {tag, "bab9f431693a8888528d5c2db933c6f222c6fd44"}}},
+    {tag, "v1.0"}}},
   {ej, ".*",     {git, "git://github.com/seth/ej.git",
-    {tag, "0332523799fdbab4b7c8e87074dcf57bb15005a6"}}}
+    {tag, "0.0.3"}}}
 ]}.


### PR DESCRIPTION
Updating to the latest versions of the dependencies and also switching to using tags instead of commit
references to help rebar3 work with it. 
